### PR TITLE
Split host from port

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -26,6 +26,9 @@ func getHost(urlString string) (string, error) {
 	}
 
 	host, _, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return "", err
+	}
 	return host, nil
 }
 

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"net/url"
 	"time"
 )
@@ -24,7 +25,8 @@ func getHost(urlString string) (string, error) {
 		return "", err
 	}
 
-	return u.Host, nil
+	host, _, err := net.SplitHostPort(u.Host)
+	return host, nil
 }
 
 func getPathParams(urlString string) (string, error) {


### PR DESCRIPTION
Splits the host from the port before generating the header